### PR TITLE
History

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ cabal.project.local~
 .HTF/
 .ghc.environment.*
 stack.yaml.lock
+.vscode/*

--- a/.history
+++ b/.history
@@ -1,0 +1,17 @@
+quit
+gains 
+science
+this is a test
+quit
+sciencetest 
+gains
+quit
+sciencetest
+quit
+science
+quit
+ls
+quit
+test
+test2
+test

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,5 +4,7 @@ import History
 
 import Lib
 
+import Data.Trie
+
 main :: IO ()
-main = someFunc
+main = someFunc 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,5 +1,7 @@
 module Main where
 
+import History
+
 import Lib
 
 main :: IO ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,9 +2,19 @@ module Main where
 
 import History
 
-import Lib
-
 import Data.Trie
 
+import Lib
+
+import ConsolePrompt
+
 main :: IO ()
-main = someFunc 
+main = do
+    history <- initialHistory
+    putStrLn (show history)
+    repl history
+    where
+        initialHistory :: IO HistoryTrie
+        initialHistory = do
+            raw <- readFile historyPath
+            return (foldl updateHistory empty (lines raw))

--- a/hash.cabal
+++ b/hash.cabal
@@ -35,10 +35,12 @@ library
   build-depends:
       QuickCheck
     , base >=4.7 && <5
+    , bytestring >=0.10
     , bytestring-trie >=0.2.6
     , containers
     , mtl
     , parsec
+    , utf8-string >=1.0.2
   default-language: Haskell2010
 
 executable hash-exe
@@ -51,11 +53,13 @@ executable hash-exe
   build-depends:
       QuickCheck
     , base >=4.7 && <5
+    , bytestring >=0.10
     , bytestring-trie >=0.2.6
     , containers
     , hash
     , mtl
     , parsec
+    , utf8-string >=1.0.2
   default-language: Haskell2010
 
 test-suite hash-test
@@ -69,9 +73,11 @@ test-suite hash-test
   build-depends:
       QuickCheck
     , base >=4.7 && <5
+    , bytestring >=0.10
     , bytestring-trie >=0.2.6
     , containers
     , hash
     , mtl
     , parsec
+    , utf8-string >=1.0.2
   default-language: Haskell2010

--- a/hash.cabal
+++ b/hash.cabal
@@ -25,6 +25,7 @@ source-repository head
 
 library
   exposed-modules:
+      History
       Lib
   other-modules:
       Paths_hash
@@ -32,6 +33,7 @@ library
       src
   build-depends:
       base >=4.7 && <5
+    , bytestring-trie >=0.2.6
   default-language: Haskell2010
 
 executable hash-exe
@@ -43,6 +45,7 @@ executable hash-exe
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
+    , bytestring-trie >=0.2.6
     , hash
   default-language: Haskell2010
 
@@ -56,5 +59,6 @@ test-suite hash-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
+    , bytestring-trie >=0.2.6
     , hash
   default-language: Haskell2010

--- a/hash.cabal
+++ b/hash.cabal
@@ -25,6 +25,7 @@ source-repository head
 
 library
   exposed-modules:
+      ConsolePrompt
       History
       Lib
       Types
@@ -38,8 +39,10 @@ library
     , bytestring >=0.10
     , bytestring-trie >=0.2.6
     , containers
+    , haskeline >=0.8.2
     , mtl
     , parsec
+    , transformers >=0.5.6.2
     , utf8-string >=1.0.2
   default-language: Haskell2010
 
@@ -57,8 +60,10 @@ executable hash-exe
     , bytestring-trie >=0.2.6
     , containers
     , hash
+    , haskeline >=0.8.2
     , mtl
     , parsec
+    , transformers >=0.5.6.2
     , utf8-string >=1.0.2
   default-language: Haskell2010
 
@@ -77,7 +82,9 @@ test-suite hash-test
     , bytestring-trie >=0.2.6
     , containers
     , hash
+    , haskeline >=0.8.2
     , mtl
     , parsec
+    , transformers >=0.5.6.2
     , utf8-string >=1.0.2
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -21,9 +21,12 @@ description:         Please see the README on GitHub at <https://github.com/tguj
 
 dependencies:
 - base >= 4.7 && < 5
+- bytestring-trie >= 0.2.6
 
 library:
   source-dirs: src
+  dependencies:
+  - bytestring-trie >= 0.2.6
 
 executables:
   hash-exe:

--- a/package.yaml
+++ b/package.yaml
@@ -28,6 +28,8 @@ dependencies:
 - mtl
 - bytestring >= 0.10
 - utf8-string >= 1.0.2
+- haskeline >= 0.8.2
+- transformers >= 0.5.6.2
 
 library:
   source-dirs: src
@@ -36,6 +38,8 @@ library:
   - mtl
   - bytestring >= 0.10
   - utf8-string >= 1.0.2
+  - haskeline >= 0.8.2
+  - transformers >= 0.5.6.2
 
 executables:
   hash-exe:

--- a/package.yaml
+++ b/package.yaml
@@ -26,11 +26,16 @@ dependencies:
 - containers
 - QuickCheck
 - mtl
+- bytestring >= 0.10
+- utf8-string >= 1.0.2
 
 library:
   source-dirs: src
   dependencies:
   - bytestring-trie >= 0.2.6
+  - mtl
+  - bytestring >= 0.10
+  - utf8-string >= 1.0.2
 
 executables:
   hash-exe:

--- a/src/ConsolePrompt.hs
+++ b/src/ConsolePrompt.hs
@@ -1,0 +1,52 @@
+module ConsolePrompt (repl, historyPath) where
+
+import System.Console.Haskeline
+
+import History
+import Control.Monad.IO.Class
+
+import Control.Monad.Trans.Class (lift)
+
+import Control.Monad.Trans.State (StateT, evalStateT, get, modify)
+
+import Data.Trie
+
+-- https://hackage.haskell.org/package/haskeline-0.8.2/docs/System-Console-Haskeline.html
+historySettings :: Settings (StateT HistoryTrie IO)
+historySettings = Settings {
+    complete = customComplete, -- why is it that when I change the completion function back to completeFilename, the history auto add starts working again?
+    historyFile = Just historyPath,
+    autoAddHistory = True
+}
+
+historyPath = ".history"
+
+customComplete :: CompletionFunc (StateT HistoryTrie IO)
+customComplete = completeWordWithPrev Nothing " \t" searchHistory
+
+searchHistory :: String -> String -> StateT HistoryTrie IO [Completion]
+searchHistory prefix suffix = do
+    history <- get
+    let
+        matches = findMatches history (prefix++suffix) -- we aren't matching on tokens right now, only the whole line
+    pure $ fmap (\s -> Completion s s True) (map fst matches)
+
+repl :: HistoryTrie -> IO ()
+repl initialHistory = flip evalStateT initialHistory $ runInputT historySettings loop
+    where
+        loop :: InputT (StateT HistoryTrie IO) ()
+        loop = do
+            minput <- getInputLine "% "
+            case minput of
+                Nothing -> return ()
+                Just "quit" -> outputStrLn "**Exited**"
+                Just input -> do
+                    outputStrLn $ "Input was: " ++ input
+                    lift $ modify (`updateHistory` input)
+                    loop
+
+-- need to strip whitespace from the ends of input; otherwise we get weird double entries
+-- e.g. Data.Trie.fromList [("gains",1),("gains ",1),("ls",1),("quit",6),("science",2),("sciencetest",1),("sciencetest ",1),("test",2),("test2",1),("this is a test",1)]
+-- actually hm this seems like it's kind of a Haskeline problem
+-- because it gets written out to the file with the extra space on the end
+-- I will ignore this for now

--- a/src/History.hs
+++ b/src/History.hs
@@ -1,0 +1,11 @@
+module History (test) where
+
+-- history as trie
+-- https://hackage.haskell.org/package/bytestring-trie-0.2.6/docs/Data-Trie.html
+
+import Data.Trie as Trie
+
+findMatches :: Trie -> String -> [String]
+
+test :: ()
+test = ()

--- a/src/History.hs
+++ b/src/History.hs
@@ -1,11 +1,101 @@
-module History (test) where
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE ConstraintKinds           #-}
+
+module History (findMatches, updateHistory, replT, run) where
 
 -- history as trie
 -- https://hackage.haskell.org/package/bytestring-trie-0.2.6/docs/Data-Trie.html
 
 import Data.Trie as Trie
+import Data.Trie.Convenience as TrieConvenience
+
+import qualified Data.ByteString as B
+import Data.ByteString.Lazy as BL
+import Data.ByteString as BS
+import Data.ByteString.Lazy.UTF8 as BLU
+import Data.ByteString.UTF8 as BSU
+
+import Control.Monad.State
+
+import Control.Monad.Identity
+
+import qualified Data.Bifunctor
+
+type HistoryTrie = Trie Int
+
+stringToByteString :: String -> BS.ByteString
+stringToByteString input = BL.toStrict (BLU.fromString input)
+
+findMatches :: HistoryTrie -> String -> [(String, Int)]
+findMatches history input =
+    let
+        submap = Trie.submap (stringToByteString input) history
+        matchesList = toList submap
+    in
+        Prelude.map (Data.Bifunctor.first BSU.toString) matchesList
+
+updateHistory :: HistoryTrie -> String -> HistoryTrie
+updateHistory history input = insertWith (+) (stringToByteString input) 1 history
 
 
+-- some small tests --
 
-test :: ()
-test = ()
+testHistory :: HistoryTrie
+testHistory = Trie.fromList (Prelude.map (Data.Bifunctor.first stringToByteString) [("ls -l", 1), ("ls -a", 2), ("ls", 3), ("mkdir blah", 1)])
+
+-- >>> findMatches testHistory "l"
+-- [("ls",3),("ls -a",2),("ls -l",1)]
+--
+
+-- >>> updateHistory testHistory "ls"
+-- Data.Trie.fromList [("ls",4),("ls -a",2),("ls -l",1),("mkdir blah",1)]
+--
+
+{-
+This trie implementation is wack
+I want to look up full strings given a prefix
+But most of the functions seem to return prefixes given a full string
+submap seems like the only usable one for my purposes
+I also have no idea what the value would be; frequency I guess?
+So we want upsert not insert
+
+more fundamentally, I am having type issues with the monads
+without monads, it seems decently straightfoward:
+    input is history trie + prefix, output is list of keys that match the prefix sorted by frequency
+-}
+
+-- ok let's figure out the state monad stuff
+-- if I can do that, then all that's left should be I/O
+
+-- type SomeState m = MonadState HistoryTrie m
+
+-- something :: (SomeState m) => String -> m [(String, Int)]
+-- something input = do
+--     history <- get
+--     return (findMatches history input)
+
+-- how does this work at the top level again?
+{-
+The way it worked with While+ was like...
+
+top level:
+execute store statement -> (store, error channel, print output)
+
+this calls runEval (evalS statement) (initial store)
+
+-}
+
+type MyState a = StateT HistoryTrie IO a
+
+replT :: MyState ()
+replT = do
+    str <- liftIO Prelude.getLine
+    state <- get
+    liftIO $ Prelude.putStrLn ("current state: " ++ show state)
+    liftIO $ Prelude.putStrLn ("potential suggestions: " ++ show (findMatches state str))
+    liftIO $ Prelude.putStrLn ("setting state: " ++ str)
+    put (updateHistory state str)
+    replT
+
+-- for now just do `stack ghci` and `run`; then type things and you'll see the history update
+run = runStateT replT Trie.empty

--- a/stack.yaml
+++ b/stack.yaml
@@ -42,6 +42,7 @@ packages:
 #
 extra-deps:
   - bytestring-trie-0.2.6
+  - haskeline-0.8.2
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -40,7 +40,8 @@ packages:
 # - git: https://github.com/commercialhaskell/stack.git
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 #
-# extra-deps: []
+extra-deps:
+  - bytestring-trie-0.2.6
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
do stack build, stack exec hash-exe
then you get the repl
currently even though tab is the keypress for triggering the autocomplete, im only matching on the whole line
so if your input is "blahblah l" and hit tab expecting "l" to match with "ls", it won't do anything
it would only match on "ls" specifically basically

